### PR TITLE
[CI] - Ignorar arquivos desconhecidos na etapa do prettier

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -24,7 +24,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Check prettier
-        run: npx prettier --check $(git diff --cached --name-only HEAD^)
+        run: npx prettier --check $(git diff --cached --name-only HEAD^) --ignore-unknown
 
       - name: Check lint
         run: yarn lint


### PR DESCRIPTION
A etapa de verificação do prettier estava disparando alguns erros quando alterávamos arquivos que não são entendidos pelo prettier. 

O objetivo desse PR é remover esse warning

<img src="https://user-images.githubusercontent.com/15058771/148590900-b89ac8a2-7f5c-4efd-8fe9-ed006fc5d416.png" width="600px" />
