### PR TITLE
chore: fix lint-staged

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+/**
+ * To run lint-staged with next lint must to use --file flag
+ *
+ * @see https://nextjs.org/docs/basic-features/eslint#lint-staged
+ */
+const buildEslintCommand = (filenames) => {
+  const files = filenames.map((filename) => {
+    return path.relative(process.cwd(), filename);
+  });
+
+  return `next lint --fix --file ${files.join(' --file ')}`;
+};
+
+module.exports = {
+  '*': 'prettier --write --ignore-unknown',
+  '*.{js,jsx,ts,tsx}': [buildEslintCommand],
+};

--- a/package.json
+++ b/package.json
@@ -52,9 +52,5 @@
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
-  },
-  "lint-staged": {
-    "*": "prettier --write --ignore-unknown",
-    "*.{js,jsx,ts,tsx}": "next lint --fix --file"
   }
 }


### PR DESCRIPTION
Atualmente, quando fazemos commit de vários arquivos ao mesmo tempo, o seguinte erro está acontecendo

![image](https://user-images.githubusercontent.com/15058771/148604473-05499fca-f003-4208-9037-ce9d8f94d327.png)

Isso acontece porque quando utilizamos o comando `next lint`, precisamos fazer algumas configurações extra para fazermos o eslint funcionar em conjunto com o lint-staged. [Clique aqui para ver detalhes](https://nextjs.org/docs/basic-features/eslint#lint-staged)